### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,5 +1,8 @@
 name: Deployment
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/herokwon/blog/security/code-scanning/2](https://github.com/herokwon/blog/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/deployment.yml`. This block should be placed at the top level (before `jobs:`) to apply to all jobs, unless a job requires different permissions. The minimal starting point is `contents: read`, which allows jobs to read repository contents but not modify them. If any job requires additional permissions, those can be added at the job level. In this case, neither the `deploy` nor `send-slack-message` jobs appear to require write access, so `contents: read` is sufficient. The change should be made by inserting the following block after the workflow `name` and before `on:`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
