### PR TITLE
feat: Cloudflare Workers Preview Deployment 지원 (with. GitHub `Deployments` 연동)

### DIFF
--- a/.github/workflows/deployment-sync.yml
+++ b/.github/workflows/deployment-sync.yml
@@ -1,0 +1,79 @@
+name: Deployment Status Synchronization
+
+on:
+  workflow_run:
+    workflows:
+      - Deployment
+    types:
+      - completed
+
+env:
+  CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+  HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+  HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+
+jobs:
+  parse-info:
+    name: Parse Deployment Info
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      environment: ${{ steps.url.outputs.environment }}
+      url: ${{ steps.url.outputs.url }}
+    steps:
+      - name: Download artifact for Deployment URL
+        uses: actions/download-artifact@v4
+        with:
+          name: deployment-url
+          path: ./artifacts
+        continue-on-error: true
+
+      - name: Check Deployment Info
+        id: url
+        run: |
+          ENVIRONMENT=""
+          URL=""
+
+          if [[ "$HEAD_BRANCH" == "main" ]]; then
+            ENVIRONMENT="Production"
+          else
+            ENVIRONMENT="Preview"
+          fi
+
+          if [[ "$CONCLUSION" == "success" && -s ./artifacts/deployment-url.txt ]]; then
+            URL=$(tr -d '\r\n' < ./artifacts/deployment-url.txt)
+          else
+            URL="https://github.com/herokwon/blog/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}"
+          fi
+
+          echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
+          echo "url=$URL" >> $GITHUB_OUTPUT
+
+  github-deployment:
+    name: Deployment for GitHub
+    runs-on: ubuntu-latest
+    needs: parse-info
+    timeout-minutes: 10
+    permissions:
+      deployments: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      ENVIRONMENT: ${{ needs.parse-info.outputs.environment }}
+      ENVIRONMENT_URL: ${{ needs.parse-info.outputs.url }}
+    steps:
+      - name: Create deployment
+        run: |
+          DEPLOY_ID=$(gh api repos/${{ github.repository }}/deployments \
+            -F ref=$REF \
+            -F environment=$ENVIRONMENT \
+            -q '.id')
+
+          echo "DEPLOY_ID=$DEPLOY_ID" >> $GITHUB_ENV
+
+      - name: Set Deployment Status
+        run: |
+          gh api repos/${{ github.repository }}/deployments/$DEPLOY_ID/statuses \
+            -F state="$CONCLUSION" \
+            -F environment=$ENVIRONMENT \
+            -F environment_url=$ENVIRONMENT_URL

--- a/.github/workflows/deployment-sync.yml
+++ b/.github/workflows/deployment-sync.yml
@@ -1,0 +1,78 @@
+name: Deployment Status Synchronization
+
+on:
+  workflow_run:
+    workflows:
+      - Deployment
+    types:
+      - completed
+
+jobs:
+  parse-info:
+    name: Parse Deployment Info
+    runs-on: ubuntu-latest
+    if: always()
+    outputs:
+      ref: ${{ steps.url.outputs.ref }}
+      environment: ${{ steps.url.outputs.environment }}
+      url: ${{ steps.url.outputs.url }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Download deployment-url artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: deployment-url
+          path: ./artifacts
+
+      - name: Check Deployment Info
+        id: url
+        run: |
+          REF="${{ github.sha }}"
+          CONCLUSION="${{ github.event.workflow_run.conclusion }}"
+          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+          ENVIRONMENT=""
+          URL=""
+
+          if [[ "$HEAD_BRANCH" == "main" ]]; then
+            ENVIRONMENT="production"
+          else
+            ENVIRONMENT="preview"
+          fi
+
+          if [[ "$CONCLUSION" == "success" && -s ./artifacts/deployment-url.txt ]]; then
+            URL=$(tr -d '\r\n' < ./artifacts/deployment-url.txt)
+          else
+            URL="https://github.com/herokwon/blog/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}"
+          fi
+
+          echo "ref=$REF" >> $GITHUB_OUTPUT
+          echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
+          echo "url=$URL" >> $GITHUB_OUTPUT
+
+  github-deployment:
+    name: Deployment for GitHub
+    runs-on: ubuntu-latest
+    needs: [parse-info]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+
+      - name: Create deployment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          REF="${{ github.sha }}"
+
+          ENVIRONMENT="Preview"
+
+          DEPLOY_ID=$(gh api repos/${{ github.repository }}/deployments \
+            --field ref=$REF \
+            --field environment=$ENVIRONMENT \
+            --field auto_merge=false \
+            --field required_contexts[]= \
+            -q '.id')

--- a/.github/workflows/deployment-sync.yml
+++ b/.github/workflows/deployment-sync.yml
@@ -44,7 +44,7 @@ jobs:
           if [[ "$CONCLUSION" == "success" && -s ./artifacts/deployment-url.txt ]]; then
             URL=$(tr -d '\r\n' < ./artifacts/deployment-url.txt)
           else
-            URL="https://github.com/herokwon/blog/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}"
+            URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}"
           fi
 
           echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
@@ -65,7 +65,7 @@ jobs:
       - name: Create deployment
         run: |
           DEPLOY_ID=$(gh api repos/${{ github.repository }}/deployments \
-            -F ref=$REF \
+            -F ref=$HEAD_SHA \
             -F environment=$ENVIRONMENT \
             -q '.id')
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/*
 
 permissions:
   contents: read
@@ -19,8 +20,7 @@ jobs:
     timeout-minutes: 60
     outputs:
       result: ${{ steps.deploy.outcome }}
-    permissions:
-      contents: read
+      url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -37,18 +37,18 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: ${{ github.ref_name == 'main' && 'deploy' || 'versions upload' }}
         continue-on-error: true
 
   parse-info:
-    name: Parse deployment info
+    name: Parse Deployment Info
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
     outputs:
       pr: ${{ steps.pr.outputs.result }}
-      worker-name: ${{ steps.wrangler.outputs.name }}
-      worker-domain: ${{ steps.wrangler.outputs.domain }}
+      worker-name: ${{ steps.worker.outputs.name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -83,8 +83,8 @@ jobs:
               avatar_url: context.payload.repository.owner.avatar_url
             };
 
-      - name: Read wrangler.jsonc
-        id: wrangler
+      - name: Check info from wrangler.jsonc
+        id: worker
         run: |
           node - << 'NODE'
 
@@ -98,21 +98,34 @@ jobs:
               .replace(/^\s*\/\/.*$/mg, '');
             const json = JSON.parse(stripped);
             const name = json?.name ?? '';
-            const domain = json?.routes?.[0]?.pattern ?? '';
 
             fs.appendFileSync(process.env.GITHUB_OUTPUT, `name=${name}\n`);
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, `domain=${domain}\n`);
           } catch (e) {
             console.error('Error reading wrangler.jsonc:', e);
-
             fs.appendFileSync(process.env.GITHUB_OUTPUT, 'name=\n');
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, 'domain=\n');
           }
 
           NODE
 
+  upload-artifact:
+    name: Upload artifact for Deployment URL
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    if: ${{ needs.deploy.outputs.url != '' }}
+    permissions:
+      actions: write
+    steps:
+      - name: Create deployment-url artifact
+        run: echo "${{ needs.deploy.outputs.url }}" > deployment-url.txt
+
+      - name: Upload deployment-url artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: deployment-url
+          path: deployment-url.txt
+
   comment-pr:
-    name: Comment for deployment result
+    name: Comment for Deployment
     runs-on: ubuntu-latest
     needs: [deploy, parse-info]
     if: ${{ needs.parse-info.outputs.pr != '' }}
@@ -125,7 +138,7 @@ jobs:
           STATUS: ${{ needs.deploy.outputs.result }}
           PR_JSON: ${{ needs.parse-info.outputs.pr }}
           WORKER_NAME: ${{ needs.parse-info.outputs.worker-name }}
-          WORKER_DOMAIN: ${{ needs.parse-info.outputs.worker-domain }}
+          WORKER_DOMAIN: ${{ needs.deploy.outputs.url }}
           ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
@@ -156,8 +169,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deploy, parse-info]
     if: ${{ needs.parse-info.outputs.pr != ''  }}
-    permissions:
-      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -173,7 +184,7 @@ jobs:
           deployed: ${{ needs.deploy.outputs.result == 'success' }}
           cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           cloudflare_worker_name: ${{ needs.parse-info.outputs.worker-name }}
-          cloudflare_worker_domain: ${{ needs.parse-info.outputs.worker-domain }}
+          cloudflare_worker_domain: ${{ needs.deploy.outputs.url }}
           pr_commit: ${{ fromJSON(needs.parse-info.outputs.pr).commit }}
           pr_number: ${{ fromJSON(needs.parse-info.outputs.pr).number }}
           pr_title: ${{ fromJSON(needs.parse-info.outputs.pr).title }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -19,8 +19,7 @@ jobs:
     timeout-minutes: 60
     outputs:
       result: ${{ steps.deploy.outcome }}
-    permissions:
-      contents: read
+      url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -37,18 +36,18 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: ${{ github.ref_name == 'main' && 'deploy' || 'versions upload' }}
         continue-on-error: true
 
   parse-info:
-    name: Parse deployment info
+    name: Parse Deployment Info
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
     outputs:
       pr: ${{ steps.pr.outputs.result }}
-      worker-name: ${{ steps.wrangler.outputs.name }}
-      worker-domain: ${{ steps.wrangler.outputs.domain }}
+      worker-name: ${{ steps.worker.outputs.name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -83,8 +82,8 @@ jobs:
               avatar_url: context.payload.repository.owner.avatar_url
             };
 
-      - name: Read wrangler.jsonc
-        id: wrangler
+      - name: Check info from wrangler.jsonc
+        id: worker
         run: |
           node - << 'NODE'
 
@@ -98,21 +97,34 @@ jobs:
               .replace(/^\s*\/\/.*$/mg, '');
             const json = JSON.parse(stripped);
             const name = json?.name ?? '';
-            const domain = json?.routes?.[0]?.pattern ?? '';
 
             fs.appendFileSync(process.env.GITHUB_OUTPUT, `name=${name}\n`);
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, `domain=${domain}\n`);
           } catch (e) {
             console.error('Error reading wrangler.jsonc:', e);
-
             fs.appendFileSync(process.env.GITHUB_OUTPUT, 'name=\n');
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, 'domain=\n');
           }
 
           NODE
 
+  upload-artifact:
+    name: Upload artifact for Deployment URL
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    if: ${{ needs.deploy.outputs.url != '' }}
+    permissions:
+      actions: write
+    steps:
+      - name: Create deployment-url artifact
+        run: echo "${{ needs.deploy.outputs.url }}" > deployment-url.txt
+
+      - name: Upload deployment-url artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: deployment-url
+          path: deployment-url.txt
+
   comment-pr:
-    name: Comment for deployment result
+    name: Comment for Deployment
     runs-on: ubuntu-latest
     needs: [deploy, parse-info]
     if: ${{ needs.parse-info.outputs.pr != '' }}
@@ -125,7 +137,7 @@ jobs:
           STATUS: ${{ needs.deploy.outputs.result }}
           PR_JSON: ${{ needs.parse-info.outputs.pr }}
           WORKER_NAME: ${{ needs.parse-info.outputs.worker-name }}
-          WORKER_DOMAIN: ${{ needs.parse-info.outputs.worker-domain }}
+          WORKER_DOMAIN: ${{ needs.deploy.outputs.url }}
           ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
@@ -156,8 +168,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deploy, parse-info]
     if: ${{ needs.parse-info.outputs.pr != ''  }}
-    permissions:
-      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -173,7 +183,7 @@ jobs:
           deployed: ${{ needs.deploy.outputs.result == 'success' }}
           cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           cloudflare_worker_name: ${{ needs.parse-info.outputs.worker-name }}
-          cloudflare_worker_domain: ${{ needs.parse-info.outputs.worker-domain }}
+          cloudflare_worker_domain: ${{ needs.deploy.outputs.url }}
           pr_commit: ${{ fromJSON(needs.parse-info.outputs.pr).commit }}
           pr_number: ${{ fromJSON(needs.parse-info.outputs.pr).number }}
           pr_title: ${{ fromJSON(needs.parse-info.outputs.pr).title }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -19,8 +19,7 @@ jobs:
     timeout-minutes: 60
     outputs:
       result: ${{ steps.deploy.outcome }}
-    permissions:
-      contents: read
+      url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -37,18 +36,18 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: ${{ github.ref_name == 'main' && 'deploy' || 'versions upload' }}
         continue-on-error: true
 
   parse-info:
-    name: Parse deployment info
+    name: Parse Deployment Info
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
     outputs:
       pr: ${{ steps.pr.outputs.result }}
-      worker-name: ${{ steps.wrangler.outputs.name }}
-      worker-domain: ${{ steps.wrangler.outputs.domain }}
+      worker-name: ${{ steps.worker.outputs.name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -83,8 +82,8 @@ jobs:
               avatar_url: context.payload.repository.owner.avatar_url
             };
 
-      - name: Read wrangler.jsonc
-        id: wrangler
+      - name: Check info from wrangler.jsonc
+        id: worker
         run: |
           node - << 'NODE'
 
@@ -98,21 +97,17 @@ jobs:
               .replace(/^\s*\/\/.*$/mg, '');
             const json = JSON.parse(stripped);
             const name = json?.name ?? '';
-            const domain = json?.routes?.[0]?.pattern ?? '';
 
             fs.appendFileSync(process.env.GITHUB_OUTPUT, `name=${name}\n`);
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, `domain=${domain}\n`);
           } catch (e) {
             console.error('Error reading wrangler.jsonc:', e);
-
             fs.appendFileSync(process.env.GITHUB_OUTPUT, 'name=\n');
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, 'domain=\n');
           }
 
           NODE
 
   comment-pr:
-    name: Comment for deployment result
+    name: Comment for Deployment
     runs-on: ubuntu-latest
     needs: [deploy, parse-info]
     if: ${{ needs.parse-info.outputs.pr != '' }}
@@ -125,7 +120,7 @@ jobs:
           STATUS: ${{ needs.deploy.outputs.result }}
           PR_JSON: ${{ needs.parse-info.outputs.pr }}
           WORKER_NAME: ${{ needs.parse-info.outputs.worker-name }}
-          WORKER_DOMAIN: ${{ needs.parse-info.outputs.worker-domain }}
+          WORKER_DOMAIN: ${{ needs.deploy.outputs.url }}
           ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
@@ -156,8 +151,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deploy, parse-info]
     if: ${{ needs.parse-info.outputs.pr != ''  }}
-    permissions:
-      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -173,7 +166,7 @@ jobs:
           deployed: ${{ needs.deploy.outputs.result == 'success' }}
           cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           cloudflare_worker_name: ${{ needs.parse-info.outputs.worker-name }}
-          cloudflare_worker_domain: ${{ needs.parse-info.outputs.worker-domain }}
+          cloudflare_worker_domain: ${{ needs.deploy.outputs.url }}
           pr_commit: ${{ fromJSON(needs.parse-info.outputs.pr).commit }}
           pr_number: ${{ fromJSON(needs.parse-info.outputs.pr).number }}
           pr_title: ${{ fromJSON(needs.parse-info.outputs.pr).title }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,5 @@
 # GitHub templates
 .github/**/*.md
+
+# Cloudflare Worker types
+cloudflare-env.d.ts

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:run": "vitest run",
     "build:worker": "opennextjs-cloudflare build",
     "preview": "pnpm build:worker && wrangler dev",
+    "deploy:preview": "pnpm build:worker && wrangler versions upload",
     "deploy": "pnpm build:worker && wrangler deploy"
   },
   "dependencies": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,6 +11,7 @@
   "observability": {
     "enabled": true
   },
+  "preview_urls": true,
   "routes": [
     {
       "pattern": "blog.herokwon.dev",


### PR DESCRIPTION
## 🔍 개요

> Cloudflare Workers의 프리뷰 배포(Preview Deployment)와 GitHub `Deployments` API 연동을 지원하기 위한 PR입니다.
`main` 브랜치가 아닌 곳에서는 preview 배포가 가능하도록 워크플로우를 개선하고, GitHub Actions를 통해 배포 상태를 동기화할 수 있도록 하였습니다.

<br />

## 🛠 변경 사항

- **wrangler**
  - `preview_urls` 속성 활성화

<br / >

- **GitHub Actions**
  - `Deployment` 워크플로우 배포 및 파싱 작업 개선
  - GitHub Deployments API 연동 및 배포 상태 동기화 워크플로우 추가

<br />

## ❗ 관련 이슈

- #30 

<br />

## 💬 참고 사항 (스크린샷, URL 등)

- [Preview URLs · Cloudflare Workers docs](https://developers.cloudflare.com/workers/configuration/previews)
- [배포에 대한 REST API 엔드포인트 - GitHub Docs](https://docs.github.com/ko/rest/deployments/deployments?apiVersion=2022-11-28#create-a-deployment)