### PR TITLE
feat: 홈 페이지 게시글 목록 및 최근 글 미리보기 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export default async function RootLayout({
         <div className="fixed top-0 left-0 z-99 flex w-full justify-end px-4 py-3">
           {<AuthButton />}
         </div>
-        {children}
+        <main>{children}</main>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,10 @@
-export default function Home() {
-  return;
+import { getPosts, isError, PostList } from '@/features/Post';
+
+export default async function Home() {
+  const response = await getPosts(5);
+
+  if (isError(response)) throw new Error(response.error);
+  const { data: posts } = response;
+
+  return <PostList posts={posts} />;
 }

--- a/src/features/Post/api/getPosts.test.ts
+++ b/src/features/Post/api/getPosts.test.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 
 import { PostgrestError } from '@supabase/supabase-js';
 
+import { Post } from '../types';
 import { getErrorMessage } from '../utils';
 
 const { selectMock, orderMock } = vi.hoisted(() => ({
@@ -56,8 +57,29 @@ describe('[Features/Post] getPosts', () => {
 
     expect(selectMock).toHaveBeenCalledWith('*');
     expect(orderMock).toHaveBeenCalledWith('created_at', { ascending: false });
+
     expect(result.data).not.toBeNull();
     expect(result.error).toBeNull();
+  });
+
+  it('limit 파라미터가 제공되면 지정된 개수만큼만 조회해야 합니다.', async () => {
+    const limitMock = vi.fn().mockResolvedValueOnce({
+      data: Array.from({ length: 10 }, (_, i) => ({
+        id: `${i + 1}`,
+        title: `title${i + 1}`,
+        content: `content${i + 1}`,
+        created_at: `2025-01-${(i + 1).toString().padStart(2, '0')}`,
+        updated_at: `2025-01-${(i + 1).toString().padStart(2, '0')}`,
+      })) satisfies Post[],
+      error: null,
+    });
+
+    orderMock.mockReturnValueOnce({ limit: limitMock });
+
+    const result = await getPosts(5);
+
+    expect(limitMock).toHaveBeenCalledWith(5);
+    expect(result.data).not.toBeNull();
   });
 
   it('작업 실패 시, 적절한 오류 메시지를 반환해야 합니다.', async () => {
@@ -72,7 +94,9 @@ describe('[Features/Post] getPosts', () => {
     const result = await getPosts();
 
     expect(selectMock).toHaveBeenCalled();
+
     expect(result.data).toBeNull();
+
     expect(result.error).toBeTruthy();
     expect(result.error).toBe(getErrorMessage(error));
   });

--- a/src/features/Post/api/getPosts.ts
+++ b/src/features/Post/api/getPosts.ts
@@ -27,7 +27,8 @@ export const getPosts = async (limit?: number): Promise<GetPostsResponse> => {
     let query = supabase
       .from('posts')
       .select('*')
-      .order('created_at', { ascending: false });
+      .order('created_at', { ascending: false })
+      .order('updated_at', { ascending: false });
 
     if (limit) {
       query = query.limit(limit);

--- a/src/features/Post/api/getPosts.ts
+++ b/src/features/Post/api/getPosts.ts
@@ -27,8 +27,7 @@ export const getPosts = async (limit?: number): Promise<GetPostsResponse> => {
     let query = supabase
       .from('posts')
       .select('*')
-      .order('created_at', { ascending: false })
-      .order('updated_at', { ascending: false });
+      .order('created_at', { ascending: false });
 
     if (limit) {
       query = query.limit(limit);

--- a/src/features/Post/api/getPosts.ts
+++ b/src/features/Post/api/getPosts.ts
@@ -20,13 +20,20 @@ import { getErrorMessage } from '../utils';
  * @see {@link GetPostsResponse} - 응답 데이터 타입 정의
  * @see {@link getErrorMessage} - PostgreSQL 에러 메시지 변환 함수
  */
-export const getPosts = async (): Promise<GetPostsResponse> => {
+export const getPosts = async (limit?: number): Promise<GetPostsResponse> => {
   try {
     const supabase = await createClient();
-    const { data, error } = await supabase
+
+    let query = supabase
       .from('posts')
       .select('*')
       .order('created_at', { ascending: false });
+
+    if (limit) {
+      query = query.limit(limit);
+    }
+
+    const { data, error } = await query;
 
     return !error
       ? {

--- a/src/features/Post/api/getPosts.ts
+++ b/src/features/Post/api/getPosts.ts
@@ -13,6 +13,7 @@ import { getErrorMessage } from '../utils';
  * - created_at 기준 내림차순으로 정렬합니다.
  * - PostgreSQL/Supabase 에러를 사용자 친화적 메시지로 변환합니다.
  *
+ * @param limit - 조회할 게시글의 최대 개수 (선택 사항)
  * @returns 게시글 목록 조회 결과를 담은 Promise
  * - `data`: 게시글 배열(성공 시) 또는 `null`(실패 시)
  * - `error`: 에러 메시지(실패 시) 또는 `null`(성공 시)


### PR DESCRIPTION
## 🔍 개요

> 홈 페이지에 게시글 목록 및 최근 글 미리보기 기능을 구현합니다.

<br />

## 🛠 변경 사항

- `getPosts` API 함수에 `limit` 파라미터 추가
- 홈(`/`) 페이지에서 최근 5개 게시글 목록 표시
- 최상위 레이아웃에 `<main>` 태그 추가

<br />

## ❗ 관련 이슈

- #58