### PR TITLE
chore: Dependabot에서 `Next.js` v15 고정

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,8 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: 'tailwindcss'
         update-types: ['version-update:semver-major']
+      - dependency-name: 'next'
+        update-types: ['version-update:semver-major']
     groups:
       npm-production:
         dependency-type: production

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,8 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: 'next'
         update-types: ['version-update:semver-major']
+      - dependency-name: 'eslint-config-next'
+        update-types: ['version-update:semver-major']
     groups:
       npm-production:
         dependency-type: production


### PR DESCRIPTION
## 🔍 개요

> Dependabot에서 Next.js 및 관련 의존성에 대한 major 버전을 15로 고정하였습니다.

<br />

## 🛠 변경 사항

- Dependabot 설정에서 major 버전 업데이트 무시 의존성 추가
  - [`next`](https://npmjs.com/package/next/v/15)
  - [`eslint-config-next`](https://npmjs.com/package/eslint-config-next/v/15)

<br />

## ❗ 관련 이슈

- #93 
- #94 
- #95